### PR TITLE
Fix PG10-13 issues.

### DIFF
--- a/docs/proxy.rst
+++ b/docs/proxy.rst
@@ -22,13 +22,13 @@ PGLock
   which includes the SQL query.
 * **mode**: The lock mode.
 * **granted**: A boolean indicating if the lock has been granted or is still waiting to be acquired.
-* **wait_duration**: How long the lock has been waiting to be acquired.
+* **wait_duration**: How long the lock has been waiting to be acquired. Only available in Postgres 14 and up.
 * **rel_kind**: The type of relation for the lock, such as "TABLE" or "INDEX".
 * **rel_name**: The name of the relation, such as the table name.
 
 See `PGLock` for a list of all attributes and possible options for fields.
 
-For example, this query will show all locks and associated relations that have been blocked for over five seconds. It will
+For example, this query will show all locks that are blocked. It will
 also show which query is trying to acquire the locks.
 
 .. code-block:: python
@@ -37,8 +37,8 @@ also show which query is trying to acquire the locks.
     from pglock.models import PGLock
 
     PGLock.objects.filter(
-        wait_duration__gt=timedelta(seconds=5)
-    ).values("rel_kind", "rel_name", "wait_duration", "activity__query")
+        granted=False
+    ).values("rel_kind", "rel_name", "activity__duration", "activity__query")
 
 There are some special queryset methods worth noting:
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -10,7 +10,7 @@ PGLOCK_ATTRIBUTES
 
 The default attributes of the `PGLock` model shown by the ``pglock`` management command.
 
-**Default** ``("activity_id", "wait_duration", "mode", "rel_kind", "rel_name", "activity__context", "activity__query")``
+**Default** ``("activity_id", "activity__duration", "mode", "rel_kind", "rel_name", "activity__context", "activity__query")``
 
 PGLOCK_BLOCKING_ATTRIBUTES
 --------------------------
@@ -29,8 +29,8 @@ are referenced by their key in the dictionary.
 For example::
 
     PGLOCK_CONFIGS = {
-        "long-running": {
-            "filters": ["wait_duration__gt=1 minute"]
+        "blocked": {
+            "filters": ["granted=False"]
         }
     }
 

--- a/pglock/config.py
+++ b/pglock/config.py
@@ -8,7 +8,8 @@ def attributes():
         "PGLOCK_ATTRIBUTES",
         [
             "activity_id",
-            "wait_duration",
+            "activity__duration",
+            "granted",
             "mode",
             "rel_kind",
             "rel_name",

--- a/pglock/management/commands/pglock.py
+++ b/pglock/management/commands/pglock.py
@@ -141,7 +141,13 @@ class Command(BaseCommand):
                 )
             )
         else:
-            locks = locks.order_by(F("wait_duration").desc(nulls_last=True))
+            locks = locks.order_by(
+                "granted",
+                # Only PG14 and up has a non-null wait_duration. Sort by this first, but
+                # use activity__duration as a backup if wait_duration is null
+                F("wait_duration").desc(nulls_last=True),
+                F("activity__duration").desc(nulls_last=True),
+            )
 
             if not cfg.get("pids") and cfg.get("limit"):
                 locks = locks[: cfg["limit"]]

--- a/poetry.lock
+++ b/poetry.lock
@@ -74,7 +74,7 @@ python-versions = ">=3.5"
 dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
 docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
 tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
-tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
+tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "babel"
@@ -516,7 +516,7 @@ notebook = ["ipywidgets", "notebook"]
 parallel = ["ipyparallel"]
 qtconsole = ["qtconsole"]
 test = ["pytest (<7.1)", "pytest-asyncio", "testpath"]
-test-extra = ["curio", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.19)", "pandas", "pytest (<7.1)", "pytest-asyncio", "testpath", "trio"]
+test_extra = ["curio", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.19)", "pandas", "pytest (<7.1)", "pytest-asyncio", "testpath", "trio"]
 
 [[package]]
 name = "jedi"
@@ -581,7 +581,7 @@ typing_extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 
 [package.extras]
 benchmarking = ["psutil", "pytest", "pytest-benchmark (>=3.2,<4.0)"]
-code-style = ["pre-commit (==2.6)"]
+code_style = ["pre-commit (==2.6)"]
 compare = ["commonmark (>=0.9.1,<0.10.0)", "markdown (>=3.3.6,<3.4.0)", "mistletoe (>=0.8.1,<0.9.0)", "mistune (>=2.0.2,<2.1.0)", "panflute (>=2.1.3,<2.2.0)"]
 linkify = ["linkify-it-py (>=1.0,<2.0)"]
 plugins = ["mdit-py-plugins"]
@@ -628,7 +628,7 @@ python-versions = ">=3.7"
 markdown-it-py = ">=1.0.0,<3.0.0"
 
 [package.extras]
-code-style = ["pre-commit"]
+code_style = ["pre-commit"]
 rtd = ["attrs", "myst-parser (>=0.16.1,<0.17.0)", "sphinx-book-theme (>=0.1.0,<0.2.0)"]
 testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
 
@@ -666,7 +666,7 @@ sphinx = ">=4,<6"
 typing-extensions = "*"
 
 [package.extras]
-code-style = ["pre-commit (>=2.12,<3.0)"]
+code_style = ["pre-commit (>=2.12,<3.0)"]
 linkify = ["linkify-it-py (>=1.0,<2.0)"]
 rtd = ["ipython", "sphinx-book-theme", "sphinx-design", "sphinxcontrib.mermaid (>=0.7.1,<0.8.0)", "sphinxext-opengraph (>=0.6.3,<0.7.0)", "sphinxext-rediraffe (>=0.2.7,<0.3.0)"]
 testing = ["beautifulsoup4", "coverage[toml]", "pytest (>=6,<7)", "pytest-cov", "pytest-param-files (>=0.3.4,<0.4.0)", "pytest-regressions", "sphinx-pytest"]
@@ -1781,7 +1781,6 @@ prompt-toolkit = [
 psycopg2-binary = [
     {file = "psycopg2-binary-2.9.3.tar.gz", hash = "sha256:761df5313dc15da1502b21453642d7599d26be88bff659382f8f9747c7ebea4e"},
     {file = "psycopg2_binary-2.9.3-cp310-cp310-macosx_10_14_x86_64.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:539b28661b71da7c0e428692438efbcd048ca21ea81af618d845e06ebfd29478"},
-    {file = "psycopg2_binary-2.9.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2f2534ab7dc7e776a263b463a16e189eb30e85ec9bbe1bff9e78dae802608932"},
     {file = "psycopg2_binary-2.9.3-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6e82d38390a03da28c7985b394ec3f56873174e2c88130e6966cb1c946508e65"},
     {file = "psycopg2_binary-2.9.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:57804fc02ca3ce0dbfbef35c4b3a4a774da66d66ea20f4bda601294ad2ea6092"},
     {file = "psycopg2_binary-2.9.3-cp310-cp310-manylinux_2_24_aarch64.whl", hash = "sha256:083a55275f09a62b8ca4902dd11f4b33075b743cf0d360419e2051a8a5d5ff76"},
@@ -1815,7 +1814,6 @@ psycopg2-binary = [
     {file = "psycopg2_binary-2.9.3-cp37-cp37m-win32.whl", hash = "sha256:adf20d9a67e0b6393eac162eb81fb10bc9130a80540f4df7e7355c2dd4af9fba"},
     {file = "psycopg2_binary-2.9.3-cp37-cp37m-win_amd64.whl", hash = "sha256:2f9ffd643bc7349eeb664eba8864d9e01f057880f510e4681ba40a6532f93c71"},
     {file = "psycopg2_binary-2.9.3-cp38-cp38-macosx_10_14_x86_64.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:def68d7c21984b0f8218e8a15d514f714d96904265164f75f8d3a70f9c295667"},
-    {file = "psycopg2_binary-2.9.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e6aa71ae45f952a2205377773e76f4e3f27951df38e69a4c95440c779e013560"},
     {file = "psycopg2_binary-2.9.3-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dffc08ca91c9ac09008870c9eb77b00a46b3378719584059c034b8945e26b272"},
     {file = "psycopg2_binary-2.9.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:280b0bb5cbfe8039205c7981cceb006156a675362a00fe29b16fbc264e242834"},
     {file = "psycopg2_binary-2.9.3-cp38-cp38-manylinux_2_24_aarch64.whl", hash = "sha256:af9813db73395fb1fc211bac696faea4ca9ef53f32dc0cfa27e4e7cf766dcf24"},
@@ -1827,7 +1825,6 @@ psycopg2-binary = [
     {file = "psycopg2_binary-2.9.3-cp38-cp38-win32.whl", hash = "sha256:6472a178e291b59e7f16ab49ec8b4f3bdada0a879c68d3817ff0963e722a82ce"},
     {file = "psycopg2_binary-2.9.3-cp38-cp38-win_amd64.whl", hash = "sha256:35168209c9d51b145e459e05c31a9eaeffa9a6b0fd61689b48e07464ffd1a83e"},
     {file = "psycopg2_binary-2.9.3-cp39-cp39-macosx_10_14_x86_64.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:47133f3f872faf28c1e87d4357220e809dfd3fa7c64295a4a148bcd1e6e34ec9"},
-    {file = "psycopg2_binary-2.9.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b3a24a1982ae56461cc24f6680604fffa2c1b818e9dc55680da038792e004d18"},
     {file = "psycopg2_binary-2.9.3-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:91920527dea30175cc02a1099f331aa8c1ba39bf8b7762b7b56cbf54bc5cce42"},
     {file = "psycopg2_binary-2.9.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:887dd9aac71765ac0d0bac1d0d4b4f2c99d5f5c1382d8b770404f0f3d0ce8a39"},
     {file = "psycopg2_binary-2.9.3-cp39-cp39-manylinux_2_24_aarch64.whl", hash = "sha256:1f14c8b0942714eb3c74e1e71700cbbcb415acbc311c730370e70c578a44a25c"},

--- a/settings.py
+++ b/settings.py
@@ -29,7 +29,7 @@ PGLOCK_CONFIGS = {
     "special-fields": {"attributes": ["activity_id"]},
     "bad-pid": {"filters": ["activity_id=-1"]},
     "kill-long-blocking": {
-        "filters": ["wait_duration__gt=1 minute"],
+        "filters": ["activity__duration__gt=1 minute"],
         "yes": True,
         "blocking": True,
         "terminate": True,


### PR DESCRIPTION
The waitstart column in the pg_locks view wasn't introduced until Postgres14. If using earlier versions, ``django-pglock`` will return null for these columns.

Type: bug