### PR TITLE
Transaction-level lock support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.6.0 (2024-08-24)
+
+#### Features
+
+- Support transaction-level locks by [@wesleykendall](https://github.com/wesleykendall) in [#13](https://github.com/Opus10/django-pglock/pull/13).
+
+  Use `pglock.advisory(xact=True)` for transaction-level advisory locks. Both context manager and functional invocations are supported.
+
+#### Changes
+
+- Django 5.1 support, drop Django 3.2 support by [@wesleykendall](https://github.com/wesleykendall) in [#12](https://github.com/Opus10/django-pglock/pull/12).
+
 ## 1.5.1 (2024-04-06)
 
 #### Trivial

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Support transaction-level locks by [@wesleykendall](https://github.com/wesleykendall) in [#13](https://github.com/Opus10/django-pglock/pull/13).
 
-  Use `pglock.advisory(xact=True)` for transaction-level advisory locks. Both context manager and functional invocations are supported.
+    Use `pglock.advisory(xact=True)` for transaction-level advisory locks. Both context manager and functional invocations are supported.
 
 #### Changes
 

--- a/docs/advisory.md
+++ b/docs/advisory.md
@@ -24,7 +24,7 @@ When creating an advisory lock, remember that the lock ID is a global name acros
 
 !!! warning
 
-    [Session-based locks](https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS) are used by default. They're manually released when the context manager exits or the database connection is terminated. If connections are pooled (e.g., [pgbouncer](https://www.pgbouncer.org)) and code is killed without raising exceptions (e.g., out-of-memory errors), the lock will continue to be held until the connection is terminated. See [transaction-level locks](#transaction) for an alternative.
+    [Session-based locks](https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS) are used by default and released when the context manager exits or the database connection is terminated. If connections are pooled (e.g., [pgbouncer](https://www.pgbouncer.org)) and code is killed without raising exceptions (e.g., out-of-memory errors), locks will be held until the connection is terminated. See [transaction-level locks](#transaction) for an alternative.
 
 ## Configuring Lock Wait Time
 

--- a/docs/advisory.md
+++ b/docs/advisory.md
@@ -22,6 +22,10 @@ def my_exclusive_function():
 
 When creating an advisory lock, remember that the lock ID is a global name across the entire database. Be sure to choose meaningful names, ideally with namespaces, when serializing code with [pglock.advisory][].
 
+!!! warning
+
+    [Session-based locks](https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS) are used by default. They're manually released when the context manager exits or the database connection is terminated. If connections are pooled (e.g., [pgbouncer](https://www.pgbouncer.org)) and code is killed without raising exceptions (e.g., out-of-memory errors), the lock will continue to be held until the connection is terminated. See [transaction-level locks](#transaction) for an alternative.
+
 ## Configuring Lock Wait Time
 
 By default, [pglock.advisory][] will wait forever until the lock can be acquired. Use the `timeout` argument to change this behavior. For example, `timeout=0` will avoid waiting for the lock:
@@ -51,7 +55,8 @@ The `side_effect` argument adjusts runtime characteristics when using a timeout.
 
 ```python
 with pglock.advisory(timeout=0, side_effect=pglock.Raise):
-    # A django.db.utils.OperationalError will be thrown if the lock cannot be acquired.
+    # A django.db.utils.OperationalError will be thrown if the lock
+    # cannot be acquired.
 ```
 
 !!! note
@@ -63,9 +68,38 @@ Use `side_effect=pglock.Skip` to skip the function entirely if the lock cannot b
 ```python
 @pglock.advisory(timeout=0, side_effect=pglock.Skip)
 def one_function_at_a_time():
-    # This function runs once at a time. If this function runs anywhere else, it will be skipped.
+    # This function runs once at a time. If this function runs anywhere
+    # else, it will be skipped.
 ```
 
 ## Shared Locks
 
 Advisory locks can be acquired in shared mode using `shared=True`. Shared locks do not conflict with other shared locks. They only conflict with other exclusive locks of the same lock ID. See the [Postgres docs](https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS-TABLE) for more information.
+
+<a id="transaction"></a>
+
+## Transaction-Level Locks
+
+Use `pglock.advisory(xact=True)` to create a transaction-level advisory lock, which are released at the end of a transaction.
+
+When using the decorator or context manager, a transaction will be opened. A `RuntimeError` will be raised if a transaction is already open.
+
+Use the functional interface to acquire a lock if already in a transaction:
+
+```python
+import pglock
+from django.db import transaction
+
+with transaction.atomic():
+    ...
+    acquired = pglock.advisory("lock_id", xact=True).acquire()
+    ...
+
+# The lock is released at the end of the transaction.
+```
+
+Remember that once acquired, a transaction-level lock cannot be manually released. It will only be released when the transaction is over.
+
+!!! danger
+
+    The functional interface is only intended for transaction-level locks. Use the context manager or decorator for other use cases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ packages = [
 exclude = [
   "*/tests/"
 ]
-version = "1.5.1"
+version = "1.6.0"
 description = "Postgres locking routines and lock table access."
 authors = ["Wes Kendall"]
 classifiers = [


### PR DESCRIPTION
Supports transaction-level locks as discussed in #7 

Use `pglock.advisory(xact=True)` to create a transaction-level lock. Using it as a context manager / decorator will open a transaction or raise a `RuntimeError` if already in a transaction.

For cases when already in a transaction, one can do `pglock.advisory(xact=True).acquire()`. The lock will be released at the end of the transaction.

Docs and tests updated