### PR TITLE
Minor Typing/Docstring Improvements

### DIFF
--- a/pglock/core.py
+++ b/pglock/core.py
@@ -35,7 +35,8 @@ _R = TypeVar("_R")
 _P = ParamSpec("_P")
 
 _AdvisorySideEffect: TypeAlias = "type[Return] | type[Raise] | type[Skip] | Return | Raise | Skip"
-_ModelSideEffect: TypeAlias = "type[Return] | type[Raise] | Return | Raise "
+_ModelSideEffect: TypeAlias = "type[Return] | type[Raise] | Return | Raise"
+
 # Lock levels
 ACCESS_SHARE: Final = "ACCESS SHARE"
 ROW_SHARE: Final = "ROW SHARE"
@@ -81,8 +82,6 @@ class Skip(SideEffect):
     """
 
 
-
-
 def _cast_timeout(timeout):
     if timeout is not None and timeout is not _unset:
         if isinstance(timeout, (int, float)):
@@ -95,7 +94,6 @@ def _cast_timeout(timeout):
             timeout = dt.timedelta()
 
     return timeout
-        
 
 
 def _is_transaction_errored(cursor):
@@ -170,8 +168,7 @@ def lock_timeout(
     """
     if timedelta_kwargs:
         timeout = dt.timedelta(**timedelta_kwargs)
-
-    if type(timeout) is _Unset:
+    elif timeout is _unset:
         raise ValueError("Must supply a value to pglock.timeout")
 
     if timeout is not None:

--- a/pglock/core.py
+++ b/pglock/core.py
@@ -259,7 +259,7 @@ class advisory(contextlib.ContextDecorator):
             `pglock.Raise` will raise a `django.db.utils.OperationalError` if the lock cannot
             be acquired or a timeout happens. `pglock.Skip` will skip decoratored code if the
             lock cannot be acquired. Defaults to `pglock.Return` when used as a context manager
-            or `pglock.Raise` when used as a decorator (or when set to `None`).
+            or `pglock.Raise` when used as a decorator.
 
     Raises:
         django.db.utils.OperationalError: When a lock cannot be acquired or a timeout happens

--- a/pglock/core.py
+++ b/pglock/core.py
@@ -453,7 +453,7 @@ def model(
     mode: str = ACCESS_EXCLUSIVE,
     using: str = DEFAULT_DB_ALIAS,
     timeout: int | float | dt.timedelta | _Unset | None = _unset,
-    side_effect: _ModelSideEffect | None = None,
+    side_effect: _ModelSideEffect = Return,
 ) -> bool:
     """Lock model(s).
 

--- a/pglock/core.py
+++ b/pglock/core.py
@@ -13,7 +13,7 @@ import pgactivity
 from django.apps import apps
 from django.db import DEFAULT_DB_ALIAS, connections, models, transaction
 from django.db.utils import OperationalError
-from typing_extensions import ParamSpec, TypedDict, Unpack, TypeAlias
+from typing_extensions import ParamSpec, TypeAlias, TypedDict, Unpack
 
 from pglock import utils
 
@@ -124,10 +124,9 @@ class _TimeDeltaKwargs(TypedDict):
 @overload
 @contextlib.contextmanager
 def lock_timeout(
-    timeout: dt.timedelta | int | float | _Unset | None = _unset,
-    *,
-    using: str = DEFAULT_DB_ALIAS
+    timeout: dt.timedelta | int | float | _Unset | None = _unset, *, using: str = DEFAULT_DB_ALIAS
 ) -> Generator[None]: ...
+
 
 @overload
 @contextlib.contextmanager
@@ -350,14 +349,15 @@ class advisory(contextlib.ContextDecorator):
 
     def acquire(self) -> bool:
         """Acquire an advisory lock, returning the lock status.
-        
+
         Raises:
             ValueError: When:
                 - `side_effect` is not one of `pglock.Return`, `pglock.Raise`, or `pglock.Skip`.
                 - `side_effect` is `pglock.Skip` and the lock is being acquired as a decorator.
                 - `lock_id` is not supplied.
             RuntimeError: When acquiring outside of a transaction for `xact=True`.
-            django.db.utils.OperationalError: When a lock cannot be acquired when `side_effect=pglock.Raise`.
+            django.db.utils.OperationalError: When a lock cannot be acquired or a timeout happens
+                when `side_effect=pglock.Raise`.
         """
         self._process_runtime_parameters()
 
@@ -398,7 +398,7 @@ class advisory(contextlib.ContextDecorator):
 
     def release(self) -> None:
         """Release an advisory lock.
-        
+
         Raises:
             RuntimeError: When releasing a lock with `xact=True`.
         """


### PR DESCRIPTION
- Accurate typing for `lock_timeout`, as only one of `timedelta_kwargs`/`timeout` should be provided, along with typed dictionaries.
- Accurate side-effect typing for acquiring advisory/model locks.
- Make it clear that if `timeout` is unset it's set to the current `lock_timeout` Postgres configuration parameter.