### PR TITLE
feat: advisory.is_locked/bulk_is_locked

### DIFF
--- a/pglock/core.py
+++ b/pglock/core.py
@@ -322,7 +322,7 @@ class advisory(contextlib.ContextDecorator):
         try:
             utils._unwrap_func(func)._pglock_advisory_id = int_lock_id  # type: ignore[reportFunctionMemberAccess]
         except AttributeError:
-            pass # handle slotted/frozen dataclasses, etc
+            pass  # handle slotted/frozen dataclasses, etc
         return inner
 
     def _process_runtime_parameters(self) -> None:
@@ -429,7 +429,8 @@ class advisory(contextlib.ContextDecorator):
         """Checks if lock is currently acquired.
 
         Supports passing a callable that has been decorated by `pglock.advisory`.
-        If callable is decorated by multiple pglock.advisory - only inner lock is checked.
+        If callable is decorated by multiple pglock.advisory - 
+        only outer (latest applied) lock is checked.
 
         Raises:
             TypeError: When: `lock_id` is not supplied.
@@ -446,7 +447,8 @@ class advisory(contextlib.ContextDecorator):
         """Checks if locks are currently acquired.
 
         Supports passing a callables that has been decorated by `pglock.advisory`.
-        If callable is decorated by multiple pglock.advisory - only inner lock is checked.
+        If callable is decorated by multiple pglock.advisory - 
+        only outer (latest applied) lock is checked.
 
         Raises:
             TypeError: When: any value from `lock_ids` is not supplied.

--- a/pglock/core.py
+++ b/pglock/core.py
@@ -319,7 +319,10 @@ class advisory(contextlib.ContextDecorator):
         else:
             int_lock_id = self.int_lock_id
         # unwrap to handle other wrapping decorators - such as celery.shared_task
-        utils._unwrap_func(func)._pglock_advisory_id = int_lock_id  # type: ignore[reportFunctionMemberAccess]
+        try:
+            utils._unwrap_func(func)._pglock_advisory_id = int_lock_id  # type: ignore[reportFunctionMemberAccess]
+        except AttributeError:
+            pass # handle slotted/frozen dataclasses, etc
         return inner
 
     def _process_runtime_parameters(self) -> None:

--- a/pglock/core.py
+++ b/pglock/core.py
@@ -429,7 +429,7 @@ class advisory(contextlib.ContextDecorator):
         """Checks if lock is currently acquired.
 
         Supports passing a callable that has been decorated by `pglock.advisory`.
-        If callable is decorated by multiple pglock.advisory - 
+        If callable is decorated by multiple pglock.advisory -
         only outer (latest applied) lock is checked.
 
         Raises:
@@ -447,7 +447,7 @@ class advisory(contextlib.ContextDecorator):
         """Checks if locks are currently acquired.
 
         Supports passing a callables that has been decorated by `pglock.advisory`.
-        If callable is decorated by multiple pglock.advisory - 
+        If callable is decorated by multiple pglock.advisory -
         only outer (latest applied) lock is checked.
 
         Raises:

--- a/pglock/tests/test_core.py
+++ b/pglock/tests/test_core.py
@@ -654,3 +654,19 @@ def test_is_locked_func_raises():
 
     with pytest.raises(RuntimeError, match="not wrapped"):
         pglock.advisory.is_locked(foo)
+
+@pytest.mark.django_db()
+def test_decorator_slotted():
+    class SlottedCallable:
+        __slots__ = ("foo",)
+
+        def __call__(self):
+            return True
+
+    func = SlottedCallable()
+    func = pglock.advisory("test_decorator_slotted")(func)
+
+    with pytest.raises(RuntimeError, match="not wrapped"):
+        pglock.advisory.is_locked(func)
+
+    assert func()

--- a/pglock/tests/test_core.py
+++ b/pglock/tests/test_core.py
@@ -655,6 +655,7 @@ def test_is_locked_func_raises():
     with pytest.raises(RuntimeError, match="not wrapped"):
         pglock.advisory.is_locked(foo)
 
+
 @pytest.mark.django_db()
 def test_decorator_slotted():
     class SlottedCallable:

--- a/pglock/utils.py
+++ b/pglock/utils.py
@@ -26,3 +26,9 @@ def pg_maj_version(cursor):
     """Return the major version of Postgres that's running"""
     version = getattr(cursor.connection, "server_version", cursor.connection.info.server_version)
     return int(str(version)[:-4])
+
+
+def _unwrap_func(func):
+    while hasattr(func, "__wrapped__"):
+        func = _unwrap_func(func.__wrapped__)
+    return func


### PR DESCRIPTION
Hi. Thanks for great library and convenient CONTRIBUTING.md.
I'm currently using my own snippet for advisory_lock that's very similar, but I added functionality for checking locks, mostly to not over-spam frequent celery tasks which are not going to run anyway because of locks.

While doing this also found a bug in pglock.advisory_id - classid, objid - returned classid as negative number (mostly for string, because of signed=True), but pg_locks stores them as oid (unsigned 32 bit integers), so it was not compatible with the table.